### PR TITLE
feat: readonly (edit-only) tables + sortable/searchable/pinnable params (#84)

### DIFF
--- a/isdl/examples/kitchensink.isdl
+++ b/isdl/examples/kitchensink.isdl
@@ -944,8 +944,10 @@ actor Hero(icon: "fa-solid fa-sword", background: texture) {
     table<Spell> SecretParamTable(visibility: Visibility.gmOnly)
     // QA: image column hidden by default via the image param
     table<Spell> NoImageTable(image: false)
-    // QA: readonly table renders a static, display-only summary -- no search/Add/gear/Actions/pin chrome, columns not sortable
+    // QA: readonly = EDITING only -- no Add button, no Actions column; search/sort/pin/gear all STILL present
     readonly table<Spell> ReadonlySpells
+    // QA: view-preference params, independent of readonly -- sort/search/pin chrome gone, but Add/Actions still present
+    table<Spell> ViewOnlySpells(sortable: false, searchable: false, pinnable: false)
 }
 
 actor NPC(svg: "/icons/creatures/mammals/beast-horned-scaled-glowing-orange.webp") {

--- a/isdl/examples/kitchensink.isdl
+++ b/isdl/examples/kitchensink.isdl
@@ -944,6 +944,8 @@ actor Hero(icon: "fa-solid fa-sword", background: texture) {
     table<Spell> SecretParamTable(visibility: Visibility.gmOnly)
     // QA: image column hidden by default via the image param
     table<Spell> NoImageTable(image: false)
+    // QA: readonly table renders a static, display-only summary -- no search/Add/gear/Actions/pin chrome, columns not sortable
+    readonly table<Spell> ReadonlySpells
 }
 
 actor NPC(svg: "/icons/creatures/mammals/beast-horned-scaled-glowing-orange.webp") {

--- a/isdl/src/cli/components/vue/vue-datatable2-component-generator.ts
+++ b/isdl/src/cli/components/vue/vue-datatable2-component-generator.ts
@@ -25,7 +25,11 @@ import {
     isTableFieldsParam,
     isTableImageParam,
     isTableImageActionParam,
+    isTableSortableParam,
+    isTableSearchableParam,
+    isTablePinnableParam,
     TableImageActionParam,
+    TableSortableParam, TableSearchableParam, TablePinnableParam,
     isTimeExp,
     isTrackerExp, Layout, Property,
     isVisibilityParam, isMethodBlock, isWhereParam,
@@ -61,10 +65,17 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
     const imageActionIcon = (imageActionParam?.action.ref?.params.find(p => isIconParam(p)) as IconParam | undefined)?.value ?? "fa-solid fa-bolt";
     const imageActionColor = (imageActionParam?.action.ref?.params.find(p => isColorParam(p)) as ColorParam | undefined)?.value ?? "primary";
 
-    // `readonly` (or `locked`) tables render as static, display-only summaries: all interactive
-    // chrome -- search, Add, the column-config gear/dialog, the Actions column, the pin column,
-    // and column sorting -- is stripped. Data, image, name, and field columns still render.
+    // `readonly` (or `locked`) controls EDITING only: it hides the Add button and the Actions
+    // column (edit/duplicate/delete/send-to-chat). It does NOT affect sort, search, the pin
+    // column, or the column-config gear/dialog -- those are view preferences governed by the
+    // independent `sortable:`/`searchable:`/`pinnable:` params (default true / current behavior).
     const isReadonly = table.modifier === 'readonly' || table.modifier === 'locked';
+
+    // View-preference params, independent of `readonly` and of each other. Absent = enabled.
+    // BOOLEAN is a real boolean (grammar), so `?? true` preserves an explicit `false`.
+    const isSortable = (table.params.find(p => isTableSortableParam(p)) as TableSortableParam | undefined)?.value ?? true;
+    const isSearchable = (table.params.find(p => isTableSearchableParam(p)) as TableSearchableParam | undefined)?.value ?? true;
+    const isPinnable = (table.params.find(p => isTablePinnableParam(p)) as TablePinnableParam | undefined)?.value ?? true;
 
     // Resolve the static visibility of a column from its `visibility:` param (preferred) or its modifier.
     // Method-block visibility can't be resolved at build time, so we fall back to the modifier / default.
@@ -100,7 +111,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
             if (visibility === "hidden") return undefined;
 
             let systemPath = getSystemPath(property, [], undefined, false);
-            let sortable = !isReadonly;
+            let sortable = isSortable;
 
             if (isResourceExp(property) || isTrackerExp(property) || isDiceField(property) || isMeasuredTemplateField(property)) {
                 sortable = false;
@@ -372,7 +383,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
         const customHeaders = [
             // Image and Name are configurable columns like any other. Image is ordered first by default.
             { title: game.i18n.localize("Image"), key: 'img', sortable: false, width: '50px', maxWidth: '50px' },
-            { title: game.i18n.localize("Name"), key: 'name', sortable: ${!isReadonly}, minWidth: '120px', locked: true },
+            { title: game.i18n.localize("Name"), key: 'name', sortable: ${isSortable}, minWidth: '120px', locked: true },
             ${joinToNode(table.document.ref!.body, p => generateDataTableHeader(table.document, p), { appendNewLineIfNotEmpty: true })}
         ];
 
@@ -418,14 +429,14 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
 
         const visibleHeaders = computed(() => {
             const baseHeaders = [
-                ${isReadonly ? '' : expandToNode`{
+                ${isPinnable ? expandToNode`{
                     title: "",
                     key: 'system.pinned',
                     sortable: false,
                     width: '40px',
                     maxWidth: '40px',
                     align: 'center'
-                }`}
+                }` : ''}
             ];
 
             let customHeadersToShow = orderedHeaders.value.filter(header => header && isColumnVisible(header.key) && passesVisibility(header));
@@ -777,7 +788,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                 <v-icon icon="fa-solid ${iconParam ? iconParam.value : 'fa-table'}" size="small" />
                 &nbsp; {{ game.i18n.localize("${document.name}.${table.name}") }}
                 <v-spacer></v-spacer>
-                ${isReadonly ? '' : expandToNode`<v-text-field
+                ${isSearchable ? expandToNode`<v-text-field
                         v-model="search"
                         density="compact"
                         label="Search"
@@ -788,7 +799,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                         single-line
                         clearable
                         style="margin: 0; margin-right: 8px;"
-                ></v-text-field>
+                ></v-text-field>` : ''}
                 <v-btn
                     icon="fa-solid fa-columns"
                     size="small"
@@ -799,7 +810,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                     <v-icon>fa-solid fa-columns</v-icon>
                     <v-tooltip activator="parent" location="top">Configure Columns</v-tooltip>
                 </v-btn>
-                <v-btn
+                ${isReadonly ? '' : expandToNode`<v-btn
                     :color="primaryColor || 'primary'"
                     prepend-icon="fa-solid fa-plus"
                     rounded="0"
@@ -814,10 +825,10 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
             <v-divider></v-divider>
             
             <v-data-table
-                ${isReadonly ? '' : expandToNode`v-model:search="search"`}
+                ${isSearchable ? expandToNode`v-model:search="search"` : ''}
                 :headers="visibleHeaders"
                 :items="data"
-                ${isReadonly ? '' : expandToNode`:search="search"`}
+                ${isSearchable ? expandToNode`:search="search"` : ''}
                 hover
                 density="compact"
                 hide-default-footer
@@ -853,7 +864,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                 </template>
 
                 <!-- Pinned slot -->
-                ${isReadonly ? '' : expandToNode`<template v-slot:item.system.pinned="{ item }">
+                ${isPinnable ? expandToNode`<template v-slot:item.system.pinned="{ item }">
                     <div class="d-flex justify-center">
                         <v-btn
                             icon
@@ -869,7 +880,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                             ></v-icon>
                         </v-btn>
                     </div>
-                </template>`}
+                </template>` : ''}
 
                 <!-- Custom field slots -->
                 ${joinToNode(table.document.ref!.body, p => generateSlotTemplate(table.document, p), { appendNewLineIfNotEmpty: true })}
@@ -961,8 +972,8 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
             </v-data-table>
         </v-card>
 
-        <!-- Column Configuration Dialog -->
-        ${isReadonly ? '' : expandToNode`<v-dialog v-model="showColumnDialog" max-width="600px">
+        <!-- Column Configuration Dialog (always available; a view preference, not editing) -->
+        <v-dialog v-model="showColumnDialog" max-width="600px">
             <v-card>
                 <v-card-title class="d-flex align-center">
                     <v-icon class="me-2">fa-solid fa-columns</v-icon>
@@ -1024,7 +1035,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                     </v-btn>
                 </v-card-actions>
             </v-card>
-        </v-dialog>`}
+        </v-dialog>
     </template>
     `;
     fs.writeFileSync(generatedFilePath, toString(fileNode));

--- a/isdl/src/cli/components/vue/vue-datatable2-component-generator.ts
+++ b/isdl/src/cli/components/vue/vue-datatable2-component-generator.ts
@@ -61,6 +61,11 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
     const imageActionIcon = (imageActionParam?.action.ref?.params.find(p => isIconParam(p)) as IconParam | undefined)?.value ?? "fa-solid fa-bolt";
     const imageActionColor = (imageActionParam?.action.ref?.params.find(p => isColorParam(p)) as ColorParam | undefined)?.value ?? "primary";
 
+    // `readonly` (or `locked`) tables render as static, display-only summaries: all interactive
+    // chrome -- search, Add, the column-config gear/dialog, the Actions column, the pin column,
+    // and column sorting -- is stripped. Data, image, name, and field columns still render.
+    const isReadonly = table.modifier === 'readonly' || table.modifier === 'locked';
+
     // Resolve the static visibility of a column from its `visibility:` param (preferred) or its modifier.
     // Method-block visibility can't be resolved at build time, so we fall back to the modifier / default.
     function getStaticColumnVisibility(property: Property): string {
@@ -95,7 +100,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
             if (visibility === "hidden") return undefined;
 
             let systemPath = getSystemPath(property, [], undefined, false);
-            let sortable = true;
+            let sortable = !isReadonly;
 
             if (isResourceExp(property) || isTrackerExp(property) || isDiceField(property) || isMeasuredTemplateField(property)) {
                 sortable = false;
@@ -291,9 +296,10 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
     }
 
     // Optional `where:` filter -- translates to a JS predicate over each item (the iteration
-    // variable is `item`, matching ItemAccess's `item.system.<field>` translation). Note: choice
-    // fields are stored as {value,...} objects, so `where: item.SomeChoice equals "X"` won't match
-    // (it compares the object); use plain string/number/boolean fields in where clauses.
+    // variable is `item`, matching ItemAccess's `item.system.<field>` translation). Choice fields
+    // are stored as {value,...} objects, but `where: item.SomeChoice equals "X"` works for
+    // `choice<string>` and `choice<damageType>`: method-generator auto-resolves those to `.value`.
+    // Document choices (`choice<Doc>`) are NOT auto-resolved, so compare those by their explicit path.
     const whereParam = table.params.find(x => isWhereParam(x)) as WhereParam | undefined;
     const whereClause = whereParam ? translateExpression(entry, id, whereParam.value) : undefined;
 
@@ -366,7 +372,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
         const customHeaders = [
             // Image and Name are configurable columns like any other. Image is ordered first by default.
             { title: game.i18n.localize("Image"), key: 'img', sortable: false, width: '50px', maxWidth: '50px' },
-            { title: game.i18n.localize("Name"), key: 'name', sortable: true, minWidth: '120px', locked: true },
+            { title: game.i18n.localize("Name"), key: 'name', sortable: ${!isReadonly}, minWidth: '120px', locked: true },
             ${joinToNode(table.document.ref!.body, p => generateDataTableHeader(table.document, p), { appendNewLineIfNotEmpty: true })}
         ];
 
@@ -412,28 +418,28 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
 
         const visibleHeaders = computed(() => {
             const baseHeaders = [
-                {
+                ${isReadonly ? '' : expandToNode`{
                     title: "",
                     key: 'system.pinned',
                     sortable: false,
                     width: '40px',
                     maxWidth: '40px',
                     align: 'center'
-                }
+                }`}
             ];
 
             let customHeadersToShow = orderedHeaders.value.filter(header => header && isColumnVisible(header.key) && passesVisibility(header));
 
             const actionHeaders = [
-                { 
-                    title: game.i18n.localize("Actions"), 
-                    key: 'actions', 
+                ${isReadonly ? '' : expandToNode`{
+                    title: game.i18n.localize("Actions"),
+                    key: 'actions',
                     sortable: false,
                     width: '150px',
                     align: 'center'
-                }
+                }`}
             ];
-            
+
             return [...baseHeaders, ...customHeadersToShow, ...actionHeaders];
         });
         
@@ -771,7 +777,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                 <v-icon icon="fa-solid ${iconParam ? iconParam.value : 'fa-table'}" size="small" />
                 &nbsp; {{ game.i18n.localize("${document.name}.${table.name}") }}
                 <v-spacer></v-spacer>
-                <v-text-field
+                ${isReadonly ? '' : expandToNode`<v-text-field
                         v-model="search"
                         density="compact"
                         label="Search"
@@ -803,15 +809,15 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                     style="max-width: 80px; height: 38px;"
                 >
                     {{ game.i18n.localize("Add") }}
-                </v-btn>
+                </v-btn>`}
             </v-card-title>
             <v-divider></v-divider>
             
             <v-data-table
-                v-model:search="search"
+                ${isReadonly ? '' : expandToNode`v-model:search="search"`}
                 :headers="visibleHeaders"
                 :items="data"
-                :search="search"
+                ${isReadonly ? '' : expandToNode`:search="search"`}
                 hover
                 density="compact"
                 hide-default-footer
@@ -847,7 +853,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                 </template>
 
                 <!-- Pinned slot -->
-                <template v-slot:item.system.pinned="{ item }">
+                ${isReadonly ? '' : expandToNode`<template v-slot:item.system.pinned="{ item }">
                     <div class="d-flex justify-center">
                         <v-btn
                             icon
@@ -856,20 +862,20 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                             @click="togglePin(item)"
                             :data-tooltip="item.system.pinned ? 'Unpin' : 'Pin'"
                         >
-                            <v-icon 
+                            <v-icon
                                 :icon="item.system.pinned ? 'fa-solid fa-thumbtack' : 'fa-regular fa-thumbtack'"
                                 :color="item.system.pinned ? primaryColor : 'grey'"
                                 size="small"
                             ></v-icon>
                         </v-btn>
                     </div>
-                </template>
+                </template>`}
 
                 <!-- Custom field slots -->
                 ${joinToNode(table.document.ref!.body, p => generateSlotTemplate(table.document, p), { appendNewLineIfNotEmpty: true })}
 
                 <!-- Actions slot -->
-                <template v-slot:item.actions="{ item }">
+                ${isReadonly ? '' : expandToNode`<template v-slot:item.actions="{ item }">
                     <div class="d-flex align-center justify-center ga-1">
                         ${joinToNode(primaryActions, generateActionButton, { appendNewLineIfNotEmpty: true })}
                         <v-tooltip text="Edit">
@@ -940,7 +946,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                             </v-list>
                         </v-menu>
                     </div>
-                </template>
+                </template>`}
 
                 <!-- No data slot -->
                 <template v-slot:no-data>
@@ -956,7 +962,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
         </v-card>
 
         <!-- Column Configuration Dialog -->
-        <v-dialog v-model="showColumnDialog" max-width="600px">
+        ${isReadonly ? '' : expandToNode`<v-dialog v-model="showColumnDialog" max-width="600px">
             <v-card>
                 <v-card-title class="d-flex align-center">
                     <v-icon class="me-2">fa-solid fa-columns</v-icon>
@@ -1018,7 +1024,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                     </v-btn>
                 </v-card-actions>
             </v-card>
-        </v-dialog>
+        </v-dialog>`}
     </template>
     `;
     fs.writeFileSync(generatedFilePath, toString(fileNode));

--- a/isdl/src/language/intelligent-system-design-language.langium
+++ b/isdl/src/language/intelligent-system-design-language.langium
@@ -318,7 +318,8 @@ MacroExecute:
 TableField:
     ExpressionModifier "table" "<" document=[Document:ID] ">" name=ID ("(" params+=TableParams ("," params+=TableParams)* ")")?;
 TableParams:
-    (StandardFieldParams | WhereParam | TableFieldsParam | TableImageParam | TableImageActionParam);
+    (StandardFieldParams | WhereParam | TableFieldsParam | TableImageParam | TableImageActionParam
+     | TableSortableParam | TableSearchableParam | TablePinnableParam);
 SingleDocumentExp:
     ExpressionModifier document=[Document:ID] name=ID StandardFieldParamsFrag;
 DocumentChoiceExp:
@@ -333,6 +334,12 @@ TableImageParam:
     "image:" value=BOOLEAN;
 TableImageActionParam:
     "imageAction:" action=[Action:ID];
+TableSortableParam:
+    "sortable:" value=BOOLEAN;
+TableSearchableParam:
+    "searchable:" value=BOOLEAN;
+TablePinnableParam:
+    "pinnable:" value=BOOLEAN;
 
 // Inventory -------------
 

--- a/isdl/src/test/parsing/table-params.test.ts
+++ b/isdl/src/test/parsing/table-params.test.ts
@@ -1,0 +1,73 @@
+import { EmptyFileSystem } from 'langium';
+import { parseHelper } from 'langium/test';
+import { describe, it, expect } from 'vitest';
+import { createIntelligentSystemDesignLanguageServices } from '../../language/intelligent-system-design-language-module.js';
+import {
+    Entry,
+    isActor,
+    isTableField,
+    isTableSortableParam,
+    isTableSearchableParam,
+    isTablePinnableParam,
+} from '../../language/generated/ast.js';
+
+const services = createIntelligentSystemDesignLanguageServices(EmptyFileSystem);
+const parse = parseHelper<Entry>(services.IntelligentSystemDesignLanguage);
+
+const PREAMBLE = `config T {
+    id = "t"
+}
+
+item Spell {
+    string Kind
+}
+`;
+
+async function parseEntry(src: string) {
+    const doc = await parse(PREAMBLE + src, { validation: true });
+    const diags = (doc.diagnostics ?? []).filter(d => d.severity === 1);
+    return { entry: doc.parseResult.value, diags };
+}
+
+function tableParams(entry: Entry, tableName: string) {
+    const actor = entry.documents.find(isActor);
+    const table = actor!.body.find(p => isTableField(p) && p.name === tableName);
+    return (table as any)?.params ?? [];
+}
+
+describe('table view-preference params', () => {
+
+    it('parses sortable:/searchable:/pinnable: with no validation errors', async () => {
+        const { entry, diags } = await parseEntry(`actor A {
+    table<Spell> Spells(sortable: false, searchable: false, pinnable: false)
+}`);
+        expect(diags).toHaveLength(0);
+
+        const params = tableParams(entry, 'Spells');
+        expect(params.find((p: any) => isTableSortableParam(p))?.value).toBe(false);
+        expect(params.find((p: any) => isTableSearchableParam(p))?.value).toBe(false);
+        expect(params.find((p: any) => isTablePinnableParam(p))?.value).toBe(false);
+    });
+
+    it('accepts the params with true values too', async () => {
+        const { entry, diags } = await parseEntry(`actor A {
+    table<Spell> Spells(sortable: true, searchable: true, pinnable: true)
+}`);
+        expect(diags).toHaveLength(0);
+
+        const params = tableParams(entry, 'Spells');
+        expect(params.find((p: any) => isTableSortableParam(p))?.value).toBe(true);
+    });
+
+    it('parses readonly modifier independently of the params', async () => {
+        const { entry, diags } = await parseEntry(`actor A {
+    readonly table<Spell> Locked(sortable: false)
+}`);
+        expect(diags).toHaveLength(0);
+
+        const actor = entry.documents.find(isActor);
+        const table = actor!.body.find(p => isTableField(p) && p.name === 'Locked') as any;
+        expect(table.modifier).toBe('readonly');
+        expect(table.params.find((p: any) => isTableSortableParam(p))?.value).toBe(false);
+    });
+});


### PR DESCRIPTION
Fully implements the table customization knobs from #84: a `readonly` modifier that locks editing, plus three independent view-preference params.

## `readonly` / `locked` modifier — editing only

A `readonly` (or `locked`) modifier on a table now controls **editing only**: it hides the **Add** button and the **Actions** column (edit / duplicate / delete / send-to-chat — header and slot). It does **not** touch search, sort, the pin column, or the column-config gear/dialog — those are view preferences and stay available.

```isdl
// No Add button, no Actions column — but search, sort, pin, and the
// column-config gear all still work.
readonly table<Spell> ReadonlySpells
```

## New view-preference params

Three independent boolean params, each defaulting to `true` (current behavior). Absent = enabled.

- `sortable: false` — all columns (including Name) become non-sortable.
- `searchable: false` — hides the search field and drops the `:search` / `v-model:search` bindings on the data table. (This is also the filter control — there's no separate `filterable`.)
- `pinnable: false` — removes the pin column (header + per-row pin toggle).

```isdl
// Static view: no search, no sorting, no pin column — but Add and the
// per-row Actions still work, since it isn't readonly.
table<Spell> ViewOnlySpells(sortable: false, searchable: false, pinnable: false)
```

The params are independent of `readonly` and of each other, so they compose. To reproduce the old "strip everything" behavior:

```isdl
readonly table<Spell> X(sortable: false, searchable: false, pinnable: false)
```

The column-config gear + dialog are now **always** available — they're a view preference, not editing — so a `readonly` table can still reorder/show/hide columns.

## Grammar

Adds `TableSortableParam` / `TableSearchableParam` / `TablePinnableParam` (reusing the `BOOLEAN` terminal) to `TableParams`; AST regenerated via `langium:generate`.

## QA

Live verification against a running Foundry v14 instance (system `kitchen-sink`): regenerated, reloaded, opened a Hero sheet with two embedded spells, and inspected the Readonly Spells, View Only Spells, and (default) Vuetify Spells tabs.

| Table | Search | Sort | Pin | Gear | Add | Actions |
|---|---|---|---|---|---|---|
| `readonly` ReadonlySpells | yes | yes | yes | yes | **no** | **no** |
| ViewOnlySpells (all 3 params off) | **no** | **no** | **no** | yes | yes | yes |
| Vuetify Spells (default) | yes | yes | yes | yes | yes | yes |

DOM inspection matched on every cell; static inspection of the three generated `.vue` files agreed. `npm run langium:generate`, `npm run build`, and `npm test` (50 passing, incl. a new parsing test for the params) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
