### PR TITLE
fix: save before generate, and clearer errors for empty/missing-config files

### DIFF
--- a/isdl/src/cli/cli-util.ts
+++ b/isdl/src/cli/cli-util.ts
@@ -19,12 +19,30 @@ export async function extractDocument(fileName: string, services: LangiumCoreSer
     const document = await services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
     await services.shared.workspace.DocumentBuilder.build([document], { validation: true });
 
+    // An empty file is almost always an unsaved-editor mistake (VS Code auto-save is off by
+    // default), which otherwise surfaces as a cryptic "Expecting token of type 'config'" error.
+    if (document.textDocument.getText().trim().length === 0) {
+        console.error(chalk.yellow(
+            `${path.basename(fileName)} is empty. If you're editing it in an editor, make sure the file is saved to disk — `
+            + `VS Code's auto-save is off by default. Every ISDL system starts with a 'config { ... }' block.`
+        ));
+        process.exit(1);
+    }
+
     const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);
     if (validationErrors.length > 0) {
         console.error(chalk.red('There are validation errors:'));
         for (const validationError of validationErrors) {
             console.error(chalk.red(
                 `line ${validationError.range.start.line + 1}: ${validationError.message} [${document.textDocument.getText(validationError.range)}]`
+            ));
+        }
+        // The grammar requires `config` as the first token, so a missing/misplaced config block
+        // produces an "Expecting token of type 'config'" parser error. Point the author at the fix.
+        if (validationErrors.some(e => /Expecting token of type 'config'/.test(e.message))) {
+            console.error(chalk.yellow(
+                `\nHint: every ISDL system must begin with a 'config { ... }' block. If the file looks correct `
+                + `in your editor, make sure it's saved to disk (VS Code auto-save is off by default).`
             ));
         }
         process.exit(1);

--- a/isdl/src/extension/main.ts
+++ b/isdl/src/extension/main.ts
@@ -33,7 +33,17 @@ export function deactivate(): Thenable<void> | undefined {
 
 function registerCommands(context: vscode.ExtensionContext) {
 
-    function generate(sourceFilePath: string, destinationPath: string) {
+    async function generate(sourceFilePath: string, destinationPath: string) {
+        // Generation parses the file from disk, so flush any unsaved editor buffer first.
+        // VS Code's auto-save is off by default; without this a dirty (or freshly created,
+        // never-saved) file would generate from stale/empty content on disk.
+        const openDoc = vscode.workspace.textDocuments.find(
+            d => d.uri.fsPath === sourceFilePath && d.isDirty
+        );
+        if (openDoc) {
+            await openDoc.save();
+        }
+
         const cliPath = path.resolve(context.extensionPath, 'bin', 'cli.js');
         const fileName = path.basename(sourceFilePath);
 
@@ -136,7 +146,7 @@ function registerCommands(context: vscode.ExtensionContext) {
         const destinationPath = destinationFolderUri[0].fsPath;
         await context.globalState.update('lastSelectedFolder', destinationPath);
 
-        generate(sourceFilePath, destinationPath);
+        await generate(sourceFilePath, destinationPath);
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand('isdl.regenerate', async () => {
@@ -148,7 +158,7 @@ function registerCommands(context: vscode.ExtensionContext) {
             return;
         }
 
-        generate(lastSelectedFile, lastSelectedFolder);
+        await generate(lastSelectedFile, lastSelectedFolder);
     }));
 }
 


### PR DESCRIPTION
Closes a common new-user trap reported on Discord: the file looks correct in the editor, but generation fails with a cryptic `Expecting token of type 'config' but found \`\``. The root cause is that generation parses the file **from disk**, while VS Code's auto-save is off by default — so an unsaved buffer (or a freshly created, never-saved file) is generated from stale/empty content.

## Changes

**VS Code extension (`src/extension/main.ts`)**
- `generate()` now saves the source document before spawning the CLI, if it's open and dirty. `isdl.generate` / `isdl.regenerate` await it.

**CLI (`src/cli/cli-util.ts`)**
- An empty source file now prints a friendly message — *"<file> is empty. … make sure the file is saved to disk … Every ISDL system starts with a `config { ... }` block."* — instead of a raw parser error.
- When the parser reports a missing `config` block, a hint is appended pointing at the fix (add `config { }` / save the file).

## QA

- **CLI — verified.** Ran the built CLI against (a) an empty `.isdl` and (b) a file with content but no `config` block. Both produce the new friendly messages; the missing-`config` case shows the parser error followed by the hint.
- **Extension save-on-generate — needs a manual pass.** Compiles cleanly (`npm run build`); the save logic is straightforward but I couldn't exercise it in a live VS Code extension host here. Recommend a quick manual check: edit a `.isdl` without saving, run **ISDL: Generate**, confirm it generates the current buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
