### PR TITLE
fix: attribute roll codegen (block-style rolls, roll-under thresholds, fail-on-build-error)

### DIFF
--- a/isdl/examples/kitchensink.isdl
+++ b/isdl/examples/kitchensink.isdl
@@ -688,6 +688,23 @@ actor Hero(icon: "fa-solid fa-sword", background: texture) {
             attribute Grit(min: 1, max: 6, style: plain, roll: roll(d20 + self.Grit))
             // QA: attribute `function:` click handler (mutually exclusive with roll:)
             attribute Brawl(min: 1, max: 30, style: plain, icon: "fa-solid fa-hand-fist", function: BrawlAttack)
+            // QA: roll-under with `success: <= self.X` (self.X threshold must resolve in scope)
+            attribute RollUnder(min: 0, max: 100, initial: 40, roll: roll(d100, success: <= self.RollUnder))
+            // QA: block-style `roll: { ... }` (emits its own statements + chat cards, not a wrapped Roll)
+            attribute BlockRoll(min: 0, max: 100, initial: 40, roll: {
+                fleeting result = roll(d100)
+                if (result <= self.BlockRoll) {
+                    chat Roll {
+                        flavor "Success!"
+                        result
+                    }
+                } else {
+                    chat Roll {
+                        flavor "Failure!"
+                        result
+                    }
+                }
+            })
         }
 
         section PlainAttributes {

--- a/isdl/src/cli/components/vue/vue-generator.ts
+++ b/isdl/src/cli/components/vue/vue-generator.ts
@@ -107,7 +107,11 @@ export async function runViteBuild(destination: string) {
         await build(config);
     }
     catch (e) {
+        // Surface the real Vite/Rollup error and re-throw so the caller's
+        // `await runViteBuild` rejects. generator.ts -> main.ts then exits
+        // non-zero, instead of silently reporting success on a broken build.
         console.error(e);
+        throw e;
     }
 }
 

--- a/isdl/src/cli/components/vue/vue-sheet-application-generator.ts
+++ b/isdl/src/cli/components/vue/vue-sheet-application-generator.ts
@@ -574,15 +574,32 @@ function generateVueComponentScript(entry: Entry, id: string, document: Document
     function generateAttributeRollMethod(attribute: AttributeExp): CompositeGeneratorNode {
         const rollParam = attribute.params.find(isAttributeRollParam) as AttributeRollParam | undefined;
         if (rollParam) {
+            // A block-style `roll: { ... }` is a method body: it declares its own variables, runs its
+            // own logic, and creates its own `chat` cards. Emit those statements directly. An
+            // expression-style `roll: roll(...)` produces a single Roll value we wrap in a chat card.
+            // `system` is provided in scope so `self.X` (which compiles to bare `system.x`) and
+            // `success:` thresholds resolve, matching the function/action handler convention.
+            if (isMethodBlock(rollParam.roll)) {
+                return expandToNode`
+                const on${toMachineIdentifier(attribute.name)}AttributeRoll = async () => {
+                    const context = {
+                        object: document
+                    };
+                    let system = context.object.system;
+                    ${translateExpression(entry, id, rollParam.roll, false, attribute)}
+                };
+                `;
+            }
             return expandToNode`
             const on${toMachineIdentifier(attribute.name)}AttributeRoll = async () => {
                 const context = {
                     object: document
                 };
+                let system = context.object.system;
                 const roll = ${translateExpression(entry, id, rollParam.roll, false, attribute)};
                 // Create the chat message
                 const ${attribute.name}Description = context.object.description ?? context.object.system.description;
-                const ${attribute.name}Context = { 
+                const ${attribute.name}Context = {
                     cssClass: "${id} ${toMachineIdentifier(attribute.name)}",
                     document: context.object,
                     description: ${attribute.name}Description,
@@ -592,7 +609,7 @@ function generateVueComponentScript(entry: Entry, id: string, document: Document
                             label: "${humanize(attribute.name)} Attribute Roll",
                             value: roll,
                             isRoll: true,
-                            wide: true, 
+                            wide: true,
                             tooltip: await roll.getTooltip()
                         }
                     ],


### PR DESCRIPTION
Fixes a cluster of bugs hit by **taikkuus** building a **d100 roll-under** system (riftbreakers2e). All three reproduce on current `main` and are fixed here, with QA fixtures added to the kitchensink.

## Bugs & root causes

### Bug 1a — block-style attribute `roll: { ... }` generates invalid JS
A `roll:` whose value is a **method block** (not a plain `roll(...)` expression) was wrapped as `const roll = <translated body>`, yielding:
```js
const roll = let result = Object.assign(await new XRoll("d100", {}).roll(), {_displayFormula: "d100"});
```
`const roll = let result = …` is a syntax error that failed the entire Vue/Vite build.

**Fix** (`vue-sheet-application-generator.ts`, `generateAttributeRollMethod`): branch on `isMethodBlock`. A block emits its own statements directly as the handler body and skips the auto chat-card scaffold (the block declares its own `fleeting`/`let`, runs its own `if`, and creates its own `chat` cards). Expression-style `roll: roll(...)` keeps the `const roll = …` wrap + chat card.

### Bug 1b — Vite build failures were swallowed and reported as SUCCESS (highest impact)
`runViteBuild` caught build errors and only `console.error`'d them, then returned normally. The CLI printed `Vite build complete` / `Intelligent System generated successfully` and exited **0** — a broken generation looked successful, left a stale bundle, and the VS Code extension (which keys off exit code) showed no error.

**Fix** (`vue-generator.ts`): re-throw after logging. The rejection propagates through `generateJavaScript` to the CLI's `generateAction`, which already exits non-zero. This un-hides **all** generation build errors, not just the one that surfaced it. (Its own commit.)

### Bug 2 — `success: <= self.X` (and `self.X` in block conditionals) referenced `system` out of scope
`self.X` compiles to a bare `system.x.value`, but the roll handler had no `system` in scope:
```js
new XRoll("d100", {}, { success: { op: "<=", value: system.armorsmithing.value } })  // ReferenceError: system is not defined
```
The literal form (`success: <= 20`) was unaffected. 

**Fix**: provide `let system = context.object.system;` in the handler — matching the existing function/action handler convention — rather than editing the shared `translateAccessExpression`, which other contexts (derived data, actions, the `(system) =>` chat-flavor closure) rely on emitting bare `system.`.

### Bug 3 — `Roll.fromData: Unable to recreate …` (resolved by Bug 2)
This was a knock-on of Bug 2: the `system is not defined` ReferenceError aborted the roll mid-flight, leaving a malformed chat message that Foundry couldn't rehydrate. With Bug 2 fixed the roll completes and serializes cleanly — verified live (see QA). No separate fix needed.

## QA fixtures (kitchensink)
Added two attributes to `Hero`'s Attributes section:
- `RollUnder` — `roll: roll(d100, success: <= self.RollUnder)`
- `BlockRoll` — block-style `roll: { fleeting result = roll(d100) if (result <= self.BlockRoll) { chat ... } else { chat ... } }`

## QA results
- `npm run build` clean; `npm test` — **47/47 pass**.
- **Regenerated taikkuus's riftbreakers2e**: Vite build now **succeeds** (was failing on `Unexpected reserved word 'let'`), CLI exits 0. Generated `strangerApp.vue` confirmed: no `const roll = let …`; block handler emits its own `if (result.total <= system.animalhandling.value)` + chat cards; `let system = context.object.system;` present in every handler; `success:` thresholds resolve (literal `value: 20`, self-ref `value: system.x.value`).
- **Bug 1b regression (both directions)**: corrupting the generated `index.mjs` → `runViteBuild` now **throws** (CLI would exit non-zero); valid input → exits 0.
- **Live QA via Chrome DevTools (Foundry v14, kitchen-sink world)**: regenerated the kitchensink into the live system and reloaded. Replicated the generated handler bodies against a live actor:
  - Roll-under: `system.rollunder.value` resolves, no ReferenceError; the custom `KitchenSinkRoll` with the `success` option **round-trips through `Roll.fromData`** (`rebuiltClass: KitchenSinkRoll`, total + success option preserved) — confirming Bug 3 is gone.
  - Block-roll: `result.total <= system.blockroll.value` branches correctly and creates a chat card with no error.

## Follow-up (not addressed here)
Generation prints chevrotain `Ambiguous Alternatives Detected` warnings around the `success: <= self.X` shorthand comparison. Non-fatal (parsing succeeds, tests pass); left as a grammar follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
