### PR TITLE
feat: support parent.Function() calls from item context

### DIFF
--- a/isdl/examples/kitchensink.isdl
+++ b/isdl/examples/kitchensink.isdl
@@ -1191,6 +1191,14 @@ item Spell {
         }
     }
 
+    // QA (#98): parent.Function() — call a function defined on the parent actor from an item.
+    // parent.FightFightFight(self.Cost) resolves at runtime to the parent sheet's function_FightFightFight method.
+    action CallParentFunction(icon: "fa-solid fa-person-running") {
+        if (parent is Hero) {
+            parent.FightFightFight(self.Cost)
+        }
+    }
+
     section Dice {
         die BonusDie
         dice DamageDice

--- a/isdl/src/cli/components/method-generator.ts
+++ b/isdl/src/cli/components/method-generator.ts
@@ -135,6 +135,7 @@ import {
     isPromptInputAccess,
     isRollResultAccess,
     isCritParam, isFumbleParam, isSuccessParam, isFailureParam,
+    isParentFunctionCall,
 } from "../../language/generated/ast.js"
 import { CompositeGeneratorNode, expandToNode, joinToNode } from 'langium/generate';
 import { getParentDocument, getPromptContainer, getPromptRegistryKey, getPromptVariable, getSystemPath, getTargetDocument, toMachineIdentifier } from './utils.js';
@@ -2025,6 +2026,26 @@ export function translateExpression(entry: Entry, id: string, expression: string
 
         return expandToNode`
             await ${accessPath}.function_${expression.method.ref?.name}(context, update, embeddedUpdate, parentUpdate, parentEmbeddedUpdate, targetUpdate, targetEmbeddedUpdate, ${args})
+        `;
+    }
+
+    if (isParentFunctionCall(expression)) {
+        console.log("Translating Parent Function Call Expression: ", expression.method);
+
+        // parent.FunctionName(args) — call a function defined on the parent actor from within an item.
+        // Resolves to the parent document's sheet function_ method at runtime.
+        // Uses the pre-threaded parentUpdate / parentEmbeddedUpdate objects as the update context.
+        // The caller's normal action flush already handles flushing parentUpdate/parentEmbeddedUpdate.
+        const args = joinToNode(expression.params, (arg) => {
+            return translateExpression(entry, id, arg, preDerived, generatingProperty)
+        }, { separator: ", " });
+
+        return expandToNode`
+            await context.object.parent?.sheet?.function_${expression.method}(
+                { object: context.object.parent },
+                parentUpdate,
+                parentEmbeddedUpdate,
+                {}, {}, {}, {}${expression.params.length ? ", " : ""}${args})
         `;
     }
 

--- a/isdl/src/cli/components/utils.ts
+++ b/isdl/src/cli/components/utils.ts
@@ -31,7 +31,7 @@ import {
     isLayout, isStringChoiceField, isTargetAccess, isDocumentChoiceExp, Access, isDiceField,
     isRoll, isDamageRoll, isChatCard, isUpdate, isPrompt, isWait,
     isPlayAudio, isMacroExecute, isAssignment, isParentAssignment,
-    isTargetAssignment, isCombat, isUser, isFunctionCall,
+    isTargetAssignment, isCombat, isUser, isFunctionCall, isParentFunctionCall,
     SettingField, isSettings, isAction, isFunctionDefinition,
 } from "../../language/generated/ast.js"
 
@@ -325,7 +325,7 @@ export function getDocument(property: Property): Document | undefined {
 const IMPURE_NODE_GUARDS: ((node: AstNode) => boolean)[] = [
     isRoll, isDamageRoll, isChatCard, isUpdate, isPrompt, isWait,
     isPlayAudio, isMacroExecute, isAssignment, isParentAssignment,
-    isTargetAssignment, isCombat, isUser,
+    isTargetAssignment, isCombat, isUser, isParentFunctionCall,
 ];
 
 /**

--- a/isdl/src/language/intelligent-system-design-language.langium
+++ b/isdl/src/language/intelligent-system-design-language.langium
@@ -661,6 +661,13 @@ MethodParam:
 
 FunctionCall:
     "self." method=[FunctionDefinition:ID] ("(" (params+=Expression ("," params+=Expression)*)? ")")?;
+
+// ParentFunctionCall: call a function defined on the parent actor from within an item.
+// `parent.Heal(amount)` resolves at runtime to calling the parent sheet's function_ method,
+// using the pre-threaded parentUpdate / parentEmbeddedUpdate objects.
+ParentFunctionCall:
+    "parent." method=ID ("(" (params+=Expression ("," params+=Expression)*)? ")")?;
+
 FunctionDefinition:
     "function" name=ID ("(" (params+=FunctionParam ("," params+=FunctionParam)*)? ")")? ("returns" returnType=(NOTHING | "number" | "boolean" | "string"))? method=MethodBlock;
 FunctionParam:
@@ -789,7 +796,7 @@ MethodBlock:
     ("{" body+=(MethodBlockExpression)* "}") | (body+=MethodBlockExpression);
 MethodBlockExpression:
     (MacroExecute | VariableExpression | Assignment | ParentAssignment | TargetAssignment | VariableAssignment | SystemSettingAssignment | ReturnExpression |
-     IfStatement | JS | ChatCard | SelfMethod | Each | Update | LogExpression | Wait | FunctionCall  | PlayAudio | Combat | User );
+     IfStatement | JS | ChatCard | SelfMethod | Each | Update | LogExpression | Wait | FunctionCall | ParentFunctionCall | PlayAudio | Combat | User );
 JS:
     js=JS_LINE;
 LogExpression:
@@ -913,7 +920,7 @@ Logical infers Expr:
 Comparison infers Expr:
     PrimitiveExpression ({infer BinaryExpression.e1=current} op=('<' | '<=' | '>' | '>=' | '==' | '!=' | 'equals' | '!equals') e2=PrimitiveExpression)*;
 PrimitiveExpression:
-    Literal | RollResultAccess | Ref | Roll | DamageRoll | Group | NegExpression | Access | EachAccess | JS | FleetingAccess | ParentAccess | TargetAccess | PromptInputAccess | ItemAccess | ArrayExpression | MathExpression | VisibilityValue | FunctionCall | CombatProperty | UserProperty | SystemSettingAccess;
+    Literal | RollResultAccess | Ref | Roll | DamageRoll | Group | NegExpression | Access | EachAccess | JS | FleetingAccess | ParentAccess | TargetAccess | PromptInputAccess | ItemAccess | ArrayExpression | MathExpression | VisibilityValue | FunctionCall | ParentFunctionCall | CombatProperty | UserProperty | SystemSettingAccess;
 ComparisonExpression:
     e1=Expression term=("<" | ">" | "<=" | ">=" | "equals" | "==" | "!equals" | "!=" | "has" | "excludes" | "startsWith" | "endsWith") e2=Expression;
 ShorthandComparisonExpression:


### PR DESCRIPTION
## Summary

- Adds a new `ParentFunctionCall` grammar expression so item-sheet functions and actions can call a function defined on the parent actor
- Compiles to `context.object.parent?.sheet?.function_Name(...)` — graceful no-op if the item has no parent document
- Marked as impure in `IMPURE_NODE_GUARDS` so it's correctly handled in derived-data contexts

## Usage

```isdl
item Spell {
    action CastSpell {
        parent.FightFightFight(self.Cost)
    }
}
```

## Test plan

- [x] All existing tests pass (64/64)
- [x] Kitchensink updated with `action CallParentFunction` on `item Spell` exercising the new expression
- [ ] Live verify: item action on actor sheet calls actor function correctly
- [ ] Verify no-parent case (standalone item) silently no-ops

Closes #98