### PR TITLE
feat: multi-type table support (table<A|B|C>)

### DIFF
--- a/isdl/examples/kitchensink.isdl
+++ b/isdl/examples/kitchensink.isdl
@@ -1054,6 +1054,8 @@ actor Hero(icon: "fa-solid fa-sword", background: texture) {
     readonly table<Spell> ReadonlySpells
     // QA: view-preference params, independent of readonly -- sort/search/pin chrome gone, but Add/Actions still present
     table<Spell> ViewOnlySpells(sortable: false, searchable: false, pinnable: false)
+    // QA: multi-type table — exercises plural document grammar, multi-type filter, and fields: requirement
+    table<Spell|Skill> AllMagicAndSkills(fields: [Category])
 }
 
 actor NPC(svg: "/icons/creatures/mammals/beast-horned-scaled-glowing-orange.webp") {
@@ -1074,6 +1076,7 @@ actor NPC(svg: "/icons/creatures/mammals/beast-horned-scaled-glowing-orange.webp
 }
 
 item Skill {
+    string Category
     //string Ability(choices: [ "Fight", "Flight", "Endure", "Persuade" ])
     parent<attribute> Ability(choices: [Hero])
     boolean Trained
@@ -1158,6 +1161,7 @@ item Equipment {
 }
 
 item Spell {
+    string Category
     choice<string> Type(choices: [
         { value: "Attack", icon: "fa-solid fa-bolt", color: #FF0000 },
         { value: "Defense", icon: "fa-solid fa-shield", color: #00FF00 },

--- a/isdl/src/cli/components/derived-data-generator.ts
+++ b/isdl/src/cli/components/derived-data-generator.ts
@@ -393,18 +393,21 @@ export function generateExtendedDocumentClasses(entry: Entry, id: string, destin
                 console.log("Processing Derived Document Array: " + property.name);
 
                 const whereParam = property.params.find(p => isWhereParam(p)) as WhereParam | undefined;
+                const typeFilter = property.documents.length > 1
+                    ? `[${property.documents.map(d => `"${d.ref?.name.toLowerCase()}"`).join(', ')}].includes(item.type)`
+                    : `item.type == "${property.documents[0]?.ref?.name.toLowerCase()}"`;
                 if ( whereParam ) {
                     return expandToNode`
                     // ${property.name} Document Array Derived Data
                     this.system.${property.name.toLowerCase()} = this.items.filter((item) => {
-                        if ( item.type !== "${property.document.ref?.name.toLowerCase()}") return false;
+                        if ( !(${typeFilter})) return false;
                         return ${translateExpression(entry, id, whereParam.value, true, property)};
                     });
                     `.appendNewLineIfNotEmpty();
                 }
                 return expandToNode`
                     // ${property.name} Document Array Derived Data
-                    this.system.${property.name.toLowerCase()} = this.items.filter((item) => item.type == "${property.document.ref?.name.toLowerCase()}");
+                    this.system.${property.name.toLowerCase()} = this.items.filter((item) => ${typeFilter});
                 `.appendNewLineIfNotEmpty();
             }
 

--- a/isdl/src/cli/components/method-generator.ts
+++ b/isdl/src/cli/components/method-generator.ts
@@ -1394,7 +1394,7 @@ export function translateExpression(entry: Entry, id: string, expression: string
                 AstUtils.getContainerOfType(expression, isDocumentChoiceExp) ??
                 AstUtils.getContainerOfType(expression, isDocumentChoicesExp) ??
                 AstUtils.getContainerOfType(expression, isInventoryField);
-            const refDoc = (whereContainer as any)?.document?.ref as Document | undefined;
+            const refDoc = ((whereContainer as any)?.documents?.[0]?.ref ?? (whereContainer as any)?.document?.ref) as Document | undefined;
             if (refDoc) {
                 const prop = AstUtils.streamAllContents(refDoc).find(
                     n => isProperty(n) && (n as Property).name.toLowerCase() === itemPropName

--- a/isdl/src/cli/components/vue/vue-datatable2-component-generator.ts
+++ b/isdl/src/cli/components/vue/vue-datatable2-component-generator.ts
@@ -92,8 +92,8 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
     if (fieldsParam) {
         defaultVisibleFields = fieldsParam.fields;
     }
-    else if (table.document.ref?.body) {
-        defaultVisibleFields = getAllOfType<Property>(table.document.ref.body, isProperty, false)
+    else if (table.documents[0]?.ref?.body) {
+        defaultVisibleFields = getAllOfType<Property>(table.documents[0].ref.body, isProperty, false)
             .map(p => p.name.toLowerCase()) ?? [];
     }
 
@@ -314,7 +314,11 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
     const whereParam = table.params.find(x => isWhereParam(x)) as WhereParam | undefined;
     const whereClause = whereParam ? translateExpression(entry, id, whereParam.value) : undefined;
 
-    let tableDocBody = table.document.ref?.body ?? [];
+    const typeFilterExpr = table.documents.length > 1
+        ? `['${table.documents.map(d => d.ref?.name.toLowerCase()).join("', '")}'].includes(i.type)`
+        : `i.type === '${table.documents[0]?.ref?.name.toLowerCase() ?? ''}'`;
+
+    let tableDocBody = table.documents[0]?.ref?.body ?? [];
     const actions = getAllOfType<Action>(tableDocBody, isAction, false);
 
     // Split actions into primary and secondary
@@ -353,7 +357,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
             // (their getters are non-enumerable), so we transiently read the live item and overlay
             // each schema field's resolved value -- the live item is never stored in reactive state.
             const allItems = props.context?.object?.items ?? [];
-            return allItems.filter(i => i.type === '${table.document.ref?.name.toLowerCase() ?? ''}').map(plain => {
+            return allItems.filter(i => ${typeFilterExpr}).map(plain => {
                 const live = document.items.get(plain._id);
                 if (live) {
                     const fields = live.system.schema?.fields ?? live.system.constructor?.schema?.fields ?? {};
@@ -384,7 +388,20 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
             // Image and Name are configurable columns like any other. Image is ordered first by default.
             { title: game.i18n.localize("Image"), key: 'img', sortable: false, width: '50px', maxWidth: '50px' },
             { title: game.i18n.localize("Name"), key: 'name', sortable: ${isSortable}, minWidth: '120px', locked: true },
-            ${joinToNode(table.document.ref!.body, p => generateDataTableHeader(table.document, p), { appendNewLineIfNotEmpty: true })}
+            ${table.documents.length > 1 && fieldsParam
+                ? joinToNode(
+                    fieldsParam.fields.map(fieldName => {
+                        for (const docRef of table.documents) {
+                            const found = getAllOfType<Property>(docRef.ref?.body ?? [], isProperty, false)
+                                .find(p => p.name.toLowerCase() === fieldName.toLowerCase());
+                            if (found) return { field: found, docRef };
+                        }
+                        return undefined;
+                    }).filter((x): x is { field: Property; docRef: Reference<Document> } => x !== undefined),
+                    ({ field, docRef }) => generateDataTableHeader(docRef, field),
+                    { appendNewLineIfNotEmpty: true }
+                  )
+                : joinToNode((table.documents[0]?.ref?.body ?? []), p => generateDataTableHeader(table.documents[0], p), { appendNewLineIfNotEmpty: true })}
         ];
 
         const orderedHeaders = computed(() => {
@@ -675,15 +692,34 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
             await foundryItem.update({"system.pinned": !foundryItem.system.pinned});
         };
 
+        ${table.documents.length > 1
+            ? joinToNode(table.documents, d => {
+                const typeName = d.ref?.name.toLowerCase() ?? '';
+                return expandToNode`
+        const addNew_${typeName} = async () => {
+            loading.value = true;
+            try {
+                const items = await Item.createDocuments([{
+                    type: '${typeName}',
+                    name: "New ${typeName}"
+                }], {parent: document});
+                if (items && items[0]) { items[0].sheet.render(true); }
+            } catch (error) {
+                console.error("Error creating item:", error);
+                ui.notifications.error("Failed to create new item");
+            } finally { loading.value = false; }
+        };`;
+            }, { appendNewLineIfNotEmpty: true })
+            : expandToNode`
         const addNewItem = async () => {
             loading.value = true;
             try {
-                const type = '${table.document.ref?.name.toLowerCase()}';
+                const type = '${table.documents[0]?.ref?.name.toLowerCase()}';
                 const items = await Item.createDocuments([{
-                    type: type, 
+                    type: type,
                     name: "New " + type
                 }], {parent: document});
-                
+
                 if (items && items[0]) {
                     items[0].sheet.render(true);
                 }
@@ -693,7 +729,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
             } finally {
                 loading.value = false;
             }
-        };
+        };`}
         
         const truncate = (text, maxLength) => {
             if (!text) return '';
@@ -810,7 +846,23 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                     <v-icon>fa-solid fa-columns</v-icon>
                     <v-tooltip activator="parent" location="top">Configure Columns</v-tooltip>
                 </v-btn>
-                ${isReadonly ? '' : expandToNode`<v-btn
+                ${isReadonly ? '' : (
+                    table.documents.length > 1
+                        ? joinToNode(table.documents, d => {
+                            const typeName = d.ref?.name.toLowerCase() ?? '';
+                            return expandToNode`<v-btn
+                    :color="primaryColor || 'primary'"
+                    prepend-icon="fa-solid fa-plus"
+                    rounded="0"
+                    size="small"
+                    :loading="loading"
+                    @click="addNew_${typeName}"
+                    style="height: 38px;"
+                >
+                    {{ game.i18n.localize("Add") }} ${d.ref?.name ?? ''}
+                </v-btn>`;
+                        }, { appendNewLineIfNotEmpty: true })
+                        : expandToNode`<v-btn
                     :color="primaryColor || 'primary'"
                     prepend-icon="fa-solid fa-plus"
                     rounded="0"
@@ -820,7 +872,8 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                     style="max-width: 80px; height: 38px;"
                 >
                     {{ game.i18n.localize("Add") }}
-                </v-btn>`}
+                </v-btn>`
+                )}
             </v-card-title>
             <v-divider></v-divider>
             
@@ -841,7 +894,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                 <!-- Image slot -->
                 <template v-slot:item.img="{ item }">
                     ${imageActionName
-                        ? expandToNode`<div class="isdl-image-action" @click.stop="customItemAction(item, '${imageActionName}')" :data-tooltip="game.i18n.localize('${table.document.ref?.name}.${imageActionParam!.action.ref!.name}')">
+                        ? expandToNode`<div class="isdl-image-action" @click.stop="customItemAction(item, '${imageActionName}')" :data-tooltip="game.i18n.localize('${table.documents[0]?.ref?.name}.${imageActionParam!.action.ref!.name}')">
                         <v-avatar size="40" rounded="0">
                             <v-img :src="item.img" :alt="item.name" cover></v-img>
                         </v-avatar>
@@ -883,7 +936,20 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                 </template>` : ''}
 
                 <!-- Custom field slots -->
-                ${joinToNode(table.document.ref!.body, p => generateSlotTemplate(table.document, p), { appendNewLineIfNotEmpty: true })}
+                ${table.documents.length > 1 && fieldsParam
+                    ? joinToNode(
+                        fieldsParam.fields.map(fieldName => {
+                            for (const docRef of table.documents) {
+                                const found = getAllOfType<Property>(docRef.ref?.body ?? [], isProperty, false)
+                                    .find(p => p.name.toLowerCase() === fieldName.toLowerCase());
+                                if (found) return { field: found, docRef };
+                            }
+                            return undefined;
+                        }).filter((x): x is { field: Property; docRef: Reference<Document> } => x !== undefined),
+                        ({ field, docRef }) => generateSlotTemplate(docRef, field),
+                        { appendNewLineIfNotEmpty: true }
+                      )
+                    : joinToNode((table.documents[0]?.ref?.body ?? []), p => generateSlotTemplate(table.documents[0], p), { appendNewLineIfNotEmpty: true })}
 
                 <!-- Actions slot -->
                 ${isReadonly ? '' : expandToNode`<template v-slot:item.actions="{ item }">
@@ -965,7 +1031,7 @@ export function generateVuetifyDatatableComponent(entry: Entry, id: string, docu
                         <v-icon size="48" color="grey-lighten-1">fa-solid fa-inbox</v-icon>
                         <div class="text-h6 mt-2">No items found</div>
                         <div class="text-body-2 text-medium-emphasis">
-                            Add your first {{ game.i18n.localize("${table.document.ref?.name}").toLowerCase() }} to get started
+                            Add your first {{ game.i18n.localize("${table.documents.length > 1 ? "item" : (table.documents[0]?.ref?.name ?? "item")}").toLowerCase() }} to get started
                         </div>
                     </div>
                 </template>

--- a/isdl/src/cli/components/vue/vue-sheet-application-generator.ts
+++ b/isdl/src/cli/components/vue/vue-sheet-application-generator.ts
@@ -1172,7 +1172,7 @@ function generateVueComponentTemplate(entry: Entry, id: string, document: Docume
         const slots = slotsParam?.value ?? 20;
         const rows = rowsParam?.value;
         const slotSize = slotSizeParam ? parseInt(slotSizeParam.value.replace('px', '')) : 60;
-        const documentType = element.document.ref?.name.toLowerCase();
+        const documentType = element.documents[0]?.ref?.name.toLowerCase();
         const quantityField = quantityParam?.field.ref?.name.toLowerCase();
         const moneyField = moneyParam?.field.ref?.name.toLowerCase();
         const moneyFieldLabel = moneyField ? `${document.name}.${moneyParam?.field?.ref?.name}` : undefined;
@@ -2311,7 +2311,7 @@ function generateVueComponentTemplate(entry: Entry, id: string, document: Docume
                 const rows = rowsParam?.value;
                 const columns = columnsParam?.value;
                 const slotSize = slotSizeParam ? parseInt(slotSizeParam.value.replace('px', '')) : 60;
-                const documentType = element.document.ref?.name.toLowerCase();
+                const documentType = element.documents[0]?.ref?.name.toLowerCase();
                 const quantityField = quantityParam?.field.ref?.name.toLowerCase();
                 const moneyField = moneyParam?.field.ref?.name.toLowerCase();
                 const moneyFieldLabel = moneyField ? `${document.name}.${moneyParam?.field?.ref?.name}` : undefined;

--- a/isdl/src/language/intelligent-system-design-language-validator.ts
+++ b/isdl/src/language/intelligent-system-design-language-validator.ts
@@ -32,6 +32,7 @@ import {
     InventoryField, isInventorySlotsParam, isInventoryRowsParam,
     isInventorySlotSizeParam, isInventoryQuantityParam, isInventoryMoneyParam,
     isInventorySumParam, isItem, isMoneyField, isActor,
+    TableField, isTableFieldsParam,
     isBinaryExpression, isLiteral, NumberExp,
     MethodBlockExpression, isReturnExpression, ResourceExp, AttributeExp,
     Action, isAction,
@@ -70,6 +71,7 @@ export function registerValidationChecks(services: IntelligentSystemDesignLangua
         TrackerExp: validator.validateTrackerExpressions,
         StringChoiceField: validator.validateStringChoiceField,
         Document: [validator.validateDependencyCycles, validator.validatePrimaryImage],
+        TableField: validator.validateTableField,
         InventoryField: validator.validateInventoryField,
         NumberExp: validator.validateNumberExp,
         ResourceExp: validator.validateResourceExp,
@@ -492,11 +494,25 @@ export class IntelligentSystemDesignLanguageValidator {
         }
     }
 
+    validateTableField(field: TableField, accept: ValidationAcceptor): void {
+        if (field.documents.length > 1) {
+            const hasFieldsParam = field.params.some(isTableFieldsParam);
+            if (!hasFieldsParam) {
+                accept('error', 'Multi-type tables require an explicit `fields:` parameter listing the shared columns', { node: field });
+            }
+        }
+    }
+
     validateInventoryField(field: InventoryField, accept: ValidationAcceptor): void {
         // Validate that inventory only references item documents
-        if (field.document.ref && isActor(field.document.ref)) {
+        if (field.documents[0]?.ref && isActor(field.documents[0].ref)) {
             accept('error', 'Inventory fields can only reference item documents, not actors.',
-                { node: field, property: 'document' });
+                { node: field, property: 'documents' });
+        }
+
+        if (field.documents.length > 1) {
+            accept('warning', 'Multi-type inventory is not yet fully supported; only the first document type will be used.',
+                { node: field });
         }
 
         const slotsParam = field.params.find(isInventorySlotsParam);
@@ -528,7 +544,7 @@ export class IntelligentSystemDesignLanguageValidator {
 
         // Validate quantity field exists on item
         if (quantityParam && quantityParam.field.ref) {
-            const itemDocument = field.document.ref;
+            const itemDocument = field.documents[0]?.ref;
             if (itemDocument && isItem(itemDocument)) {
                 const itemProperties = getAllOfType<Property>(itemDocument.body, isProperty, false);
                 const quantityField = itemProperties.find(p => p.name === quantityParam.field.ref?.name);
@@ -551,7 +567,7 @@ export class IntelligentSystemDesignLanguageValidator {
 
         // Validate sum properties exist on item and are numeric
         if (sumParam) {
-            const itemDocument = field.document.ref;
+            const itemDocument = field.documents[0]?.ref;
             if (itemDocument && isItem(itemDocument)) {
                 const itemProperties = getAllOfType<Property>(itemDocument.body, isProperty, false);
 

--- a/isdl/src/language/intelligent-system-design-language.langium
+++ b/isdl/src/language/intelligent-system-design-language.langium
@@ -449,7 +449,7 @@ MacroExecute:
 // Document Links -------------
 
 TableField:
-    ExpressionModifier "table" "<" document=[Document:ID] ">" name=ID ("(" params+=TableParams ("," params+=TableParams)* ")")?;
+    ExpressionModifier "table" "<" documents+=[Document:ID] ("|" documents+=[Document:ID])* ">" name=ID ("(" params+=TableParams ("," params+=TableParams)* ")")?;
 TableParams:
     (StandardFieldParams | WhereParam | TableFieldsParam | TableImageParam | TableImageActionParam
      | TableSortableParam | TableSearchableParam | TablePinnableParam);
@@ -477,7 +477,7 @@ TablePinnableParam:
 // Inventory -------------
 
 InventoryField:
-    ExpressionModifier "inventory" "<" document=[Document:ID] ">" name=ID ("(" params+=InventoryParams ("," params+=InventoryParams)* ")")?;
+    ExpressionModifier "inventory" "<" documents+=[Document:ID] ("|" documents+=[Document:ID])* ">" name=ID ("(" params+=InventoryParams ("," params+=InventoryParams)* ")")?;
 
 InventoryParams:
     (StandardFieldParams | WhereParam | GlobalParam |

--- a/isdl/src/language/isdl-scope-provider.ts
+++ b/isdl/src/language/isdl-scope-provider.ts
@@ -67,8 +67,8 @@ export class IsdlScopeProvider extends DefaultScopeProvider {
         // Table `imageAction:` parameter - only actions on the table's referenced item type are valid
         if (isTableImageActionParam(context.container)) {
             const tableField = AstUtils.getContainerOfType(context.container, isTableField);
-            if (!tableField || !tableField.document.ref) return new MapScope([]);
-            const actions = getAllOfType<Action>(tableField.document.ref.body, isAction, false);
+            if (!tableField || !tableField.documents[0]?.ref) return new MapScope([]);
+            const actions = getAllOfType<Action>(tableField.documents[0].ref.body, isAction, false);
             return new MapScope(actions.map(a => this.astNodeDescriptionProvider.createDescription(a, a.name)));
         }
 
@@ -205,12 +205,12 @@ export class IsdlScopeProvider extends DefaultScopeProvider {
     private getInventoryPropertyScope(context: ReferenceInfo): Scope {
         // Get the inventory field that contains this parameter
         const inventoryField = AstUtils.getContainerOfType(context.container, isInventoryField);
-        if (!inventoryField || !inventoryField.document.ref) {
+        if (!inventoryField || !inventoryField.documents[0]?.ref) {
             return new MapScope([]);
         }
 
         // Get properties from the document type that the inventory references
-        const descriptions = this.getScopesForDocument(inventoryField.document.ref);
+        const descriptions = this.getScopesForDocument(inventoryField.documents[0].ref);
         return new MapScope(descriptions);
     }
 


### PR DESCRIPTION
## Summary

- Extends `table` and `inventory` grammar to accept multiple document types separated by `|`: `table<Spell|Skill> AllAbilities(fields: [Category])`
- Multi-type tables require an explicit `fields:` param — validator errors if omitted
- Generated filter uses `["spell", "skill"].includes(i.type)` instead of `i.type === 'spell'`
- Generated component gets per-type "Add Spell" / "Add Skill" toolbar buttons instead of a single "Add" button
- Column headers and slot templates resolve each `fields:` entry from whichever listed type defines it first
- Single-type table/inventory behavior is identical to before — purely additive change
- Inventory multi-type: grammar accepts the syntax but emits a validator warning that it isn't fully wired yet (deferred to follow-up)

## Kitchensink QA

Added `string Category` to both `Skill` and `Spell` item types, and:
```isdl
table<Spell|Skill> AllMagicAndSkills(fields: [Category])
```

## Generation-verified output

- `actor.mjs`: `this.items.filter((item) => ["spell", "skill"].includes(item.type))`
- Component: two `addNew_spell` / `addNew_skill` functions with "Add Spell" / "Add Skill" buttons
- Component: `Category` column resolved from `Spell.Category`, with matching slot template
- Existing single-type tables unchanged

## Test plan

- [x] All existing tests pass
- [x] Generation verified on kitchensink
- [ ] Live verify in Foundry: multi-type table shows items of both types; each Add button creates the correct type
- [ ] Live verify: single-type tables unaffected

Closes #111
Related: #114 (template-based tables, future follow-up)